### PR TITLE
Mccalluc/start nginx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,12 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get --yes install gcc=4:4.9.2-2 zlib1g-de
 RUN conda install --yes cython==0.25.2 numpy=1.11.2
 RUN conda install --yes --channel bioconda pysam=0.9.1.4 htslib=1.3.2
 
-# TODO: Need new releases for both
+# TODO: Need new releases for all
 RUN git clone --depth 1 https://github.com/hms-dbmi/higlass-server.git --branch v0.1.0
 # TODO: Rename, and then get rid of explicit directory at the end
 RUN git clone --depth 1 https://github.com/hms-dbmi/higlass.git --branch v0.3.0 higlass-client
+# TODO: Pin the version
+RUN git clone --depth 1 https://github.com/hms-dbmi/higlass-website.git
 
 # Setup server
 WORKDIR higlass-server
@@ -30,11 +32,16 @@ WORKDIR higlass-client
 RUN npm install
 WORKDIR ..
 
+# Setup website
+WORKDIR higlass-website
+RUN npm install
+RUN npm build
+WORKDIR ..
+
 # Setup nginx
 COPY sites-enabled/* /etc/nginx/sites-enabled/
 RUN /etc/init.d/nginx restart
 
 EXPOSE 8000
-# TODO: Source also has "uwsgi --http :7000 --module api.wsgi &"
 # Given as list so that an extra shell does not need to be started.
 CMD ["uwsgi", "--socket", ":8000", "--plugins", "python", "--module", "higlass_server.wsgi"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
 FROM continuumio/miniconda:4.1.11
 
+# NOTE: Versions have been pinned everywhere. These are the latest versions at the moment, because
+# I want to ensure predictable behavior, but I don't know of any problems with higher versions:
+# It would be good to update these over time.
+
 # "pip install clodius" complained about missing gcc,
 # and "apt-get install gcc" failed and suggested apt-get update.
 RUN apt-get update
-RUN DEBIAN_FRONTEND=noninteractive apt-get --yes install gcc zlib1g-dev uwsgi-plugin-python nginx
+RUN DEBIAN_FRONTEND=noninteractive apt-get --yes install gcc=4:4.9.2-2 zlib1g-dev=1:1.2.8.dfsg-2+b1 uwsgi-plugin-python=2.0.7-1 nginx=1.6.2-5+deb8u4 npm=1.4.21+ds-2
 
 # Keep big dependencies which are unlikely to change near the top of this file.
 RUN conda install --yes cython==0.25.2 numpy=1.11.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM continuumio/miniconda:4.1.11
 # "pip install clodius" complained about missing gcc,
 # and "apt-get install gcc" failed and suggested apt-get update.
 RUN apt-get update
-RUN DEBIAN_FRONTEND=noninteractive apt-get --yes install gcc=4:4.9.2-2 zlib1g-dev=1:1.2.8.dfsg-2+b1 uwsgi-plugin-python=2.0.7-1 nginx=1.6.2-5+deb8u4 npm=1.4.21+ds-2
+RUN DEBIAN_FRONTEND=noninteractive apt-get --yes install gcc=4:4.9.2-2 zlib1g-dev=1:1.2.8.dfsg-2+b1 uwsgi-plugin-python=2.0.7-1 nginx=1.6.2-5+deb8u4 node=0.3.2-7.4 npm=1.4.21+ds-2
 
 # Keep big dependencies which are unlikely to change near the top of this file.
 RUN conda install --yes cython==0.25.2 numpy=1.11.2

--- a/sites-enabled/hgserver_nginx.conf
+++ b/sites-enabled/hgserver_nginx.conf
@@ -1,0 +1,42 @@
+# mysite_nginx.conf
+
+# the upstream component nginx needs to connect to
+upstream django {
+    # server unix:///path/to/your/mysite/mysite.sock; # for a file socket
+    server 127.0.0.1:8001; # for a web port socket (we'll use this first)
+}
+
+# configuration of the server
+server {
+    # the port your site will be served on
+    listen      80;
+    # the domain name it will serve for
+    server_name 52.45.229.11; # substitute your machine's IP address or FQDN # TODO: docker?
+
+    charset     utf-8;
+
+    # max upload size
+    client_max_body_size 10000M;   # adjust to taste
+
+    # TODO: remove if unused?
+    # Django media
+    location /media  {
+        alias /path/to/your/mysite/media;  # your Django project's media files - amend as required
+    }
+
+    location /static {
+        alias /path/to/your/mysite/static; # your Django project's static files - amend as required
+    }
+
+    location /demo {
+        alias /home/ubuntu/projects/higlass/dist;
+    }
+
+    # Finally, send all non-media requests to the Django server.
+    location / {
+        uwsgi_pass  django;
+        uwsgi_read_timeout 600;
+        # TODO: what?
+        include     /home/ubuntu/projects/higlass-server/uwsgi_params; # the uwsgi_params file you installed
+    }
+}

--- a/sites-enabled/nginx.conf
+++ b/sites-enabled/nginx.conf
@@ -1,0 +1,68 @@
+user www-data;
+worker_processes auto;
+pid /run/nginx.pid;
+
+events {
+    worker_connections 768;
+    # multi_accept on;
+}
+
+http {
+
+    ##
+    # Basic Settings
+    ##
+
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+    keepalive_timeout 65;
+    types_hash_max_size 2048;
+    # server_tokens off;
+
+  log_format   main '$remote_addr - $remote_user [$time_local]  $status '
+                    '"$request" $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent" "$http_x_forwarded_for" '
+                    '$gzip_ratio $request_time' ;
+
+    # server_names_hash_bucket_size 64;
+    # server_name_in_redirect off;
+
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    ##
+    # SSL Settings
+    ##
+
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2; # Dropping SSLv3, ref: POODLE
+    ssl_prefer_server_ciphers on;
+
+    ##
+    # Logging Settings
+    ##
+
+    access_log /var/log/nginx/access.log main;
+    error_log /var/log/nginx/error.log;
+
+    ##
+    # Gzip Settings
+    ##
+
+    gzip on;
+    gzip_disable "msie6";
+
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    gzip_buffers 16 8k;
+    gzip_http_version 1.1;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+
+    ##
+    # Virtual Host Configs
+    ##
+
+    include /etc/nginx/conf.d/*.conf;
+    include /etc/nginx/sites-enabled/*;
+}


### PR DESCRIPTION
It seems that servers the build depends on are not responding reliably:

https://travis-ci.org/hms-dbmi/higlass-docker/builds/193860922#L483
```
E: Failed to fetch http://httpredir.debian.org/debian/pool/main/n/node-rimraf/node-rimraf_2.2.8-1_all.deb  Error reading from server. Remote end closed connection [IP: 128.31.0.66 80]

E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?Fetched 69.7 MB in 26s (2645 kB/s)

The command '/bin/sh -c DEBIAN_FRONTEND=noninteractive apt-get --yes install gcc=4:4.9.2-2 zlib1g-dev=1:1.2.8.dfsg-2+b1 uwsgi-plugin-python=2.0.7-1 nginx=1.6.2-5+deb8u4 node=0.3.2-7.4 npm=1.4.21+ds-2' returned a non-zero code: 100
```

but I'm pretty sure on another run it got past that and failed somewhere else.

I need input from other folks, so I think the best thing is to commit and move forward.