### PR TITLE
Distinguish latest from default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   - sudo pip install requests # for latest.py
 
 script:
-  - sudo ./build.sh -d
+  - sudo ./build.sh -l
 
 after_success:
   - REPO=gehlenborglab/higlass

--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@ check out the corresponding repos.
 To work on the Docker deployment, checkout this repo, install Docker, and then:
 
 ```bash
-# build and run with a mounted volume of /data on port 80 with 4 workers
-./build.sh -v/data -p80 -w4
+./build.sh -l
 
 # If that doesn't work, check the port mapping:
 docker ps


### PR DESCRIPTION
Fix #78 
```
USAGE: ./build.sh -d                           # For a stable default build
       ./build.sh -l                           # Pull the latest dependencies, and timestamp container
       ./build.sh -p PORT -v VOLUME -w WORKERS # If one is given, all are required.
```

@ngehlenborg / @pkerpedjiev : I hope this does what both of you want: 
- Using `-d` will now do the same thing every time, and you are responsible for cleaning up from the previous run so the names and the port can be reused.
- Using `-l` will get the latest version of the dependencies, pick a random port, and time stamp the resulting image/container/network.