### PR TITLE
Update higlass-server URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ For more details, read [README-DEPLOY](README-DEPLOY.md).
 
 ## Development
 
-To develop [higlass-client](https://github.com/hms-dbmi/higlass) and
-[higlass-server](https://github.com/hms-dbmi/higlass-server),
+To develop [higlass-client](https://github.com/higlass/higlass) and
+[higlass-server](https://github.com/higlass/higlass-server),
 check out the corresponding repos.
 
 To work on the Docker deployment, checkout this repo, install Docker, and then:

--- a/web-context/Dockerfile.template
+++ b/web-context/Dockerfile.template
@@ -67,7 +67,7 @@ RUN pip install pybbi==<PYBBI_VERSION>
 WORKDIR /home/higlass/projects
 RUN chown higlass:higlass .
 USER higlass
-RUN git clone --depth 1 https://github.com/hms-dbmi/higlass-server.git --branch v<SERVER_VERSION>
+RUN git clone --depth 1 https://github.com/higlass/higlass-server.git --branch v<SERVER_VERSION>
 RUN git clone https://github.com/vishnubob/wait-for-it.git
 USER root
 


### PR DESCRIPTION
We are currently cloning higlass-server from `https://github.com/hms-dbmi/higlass-server.git`, but that points to https://github.com/hms-dbmi/cistrome-explorer-higlass-server. I updated the URL to clone from `higlass/higlass-server`